### PR TITLE
Fix React app initialization and HTML scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>webUI Test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,3 +9,5 @@ const App: React.FC = () => {
   );
 };
 
+export default App;
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- restore complete React root render and export
- add minimal Vite `index.html` for browser entry
- ignore build artifacts and node_modules

## Testing
- `npx --yes vitest run` *(fails: No test files found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a9dd8e53c83288a5d742406b60de4